### PR TITLE
Fix jest types for test files

### DIFF
--- a/solution/server/tests/unit/example.test.ts
+++ b/solution/server/tests/unit/example.test.ts
@@ -1,6 +1,7 @@
 import * as AWSMock from 'jest-aws-sdk-mock'
 import AWS, { AWSError } from 'aws-sdk'
 import { GetItemInput, AttributeValue, GetItemOutput } from 'aws-sdk/clients/dynamodb'
+import { it, expect } from '@jest/globals'
 
 it('should sum work', async () => {
 	expect(4 + 3).toEqual(7)

--- a/solution/server/tests/unit/user-data-access.test.ts
+++ b/solution/server/tests/unit/user-data-access.test.ts
@@ -13,9 +13,9 @@ import {
 	ScanOutput,
 } from 'aws-sdk/clients/dynamodb'
 import * as uuid from 'uuid'
-
 import { AddUserAsync, DeleteUserAsync, GetUserByIdAsync, ListUsersAsync, UpdateUserAsync } from '../../src/user-data-access'
 import { UserInput, UserListParams, UserPaginatedResponse } from '../../src/types'
+import { jest, beforeAll, describe, it, expect, beforeEach } from '@jest/globals'
 
 beforeAll(() => {
 	AWSMock.setSDKInstance(AWS)


### PR DESCRIPTION
With test files excluded in tsconfig.json , it is needed to explicitly import jest functions from globals to have type support 