### PR TITLE
Add and Update user checks

### DIFF
--- a/solution/server/src/mapbox-access.ts
+++ b/solution/server/src/mapbox-access.ts
@@ -46,8 +46,8 @@ export const FindAddressAsync = async (service: GeocodeService, query: string): 
  * @param response The response received from Mapbox API, used to check status code
  */
 const checkResponseStatusCode = (response: MapiResponse) => {
-	const codeMod = response.statusCode % 100
-	if (codeMod == 4 || codeMod == 5) {
+	// Checing if the response has a bad status code
+	if (response.statusCode >= 400 && response.statusCode < 600) {
 		const errorMessage = `Response has no success code: ${response.statusCode}`
 		console.log(errorMessage, response.body)
 		throw new ApolloError(errorMessage, response.body)

--- a/solution/server/src/user-data-access.ts
+++ b/solution/server/src/user-data-access.ts
@@ -147,7 +147,7 @@ export const AddUserAsync = async (db: DocumentClient, fields: UserInput): Promi
 	const addUserData = genUserDataMap(fields) as PutItemInputAttributeMap
 	addUserData['id'] = uuidv4() as AttributeValue
 	addUserData['createdAt'] = addUserData['updatedAt']
-	return AddOrUpdateUserAsync(db, addUserData)
+	return AddOrUpdateUserAsync(db, addUserData, true)
 }
 
 /**
@@ -169,11 +169,17 @@ export const UpdateUserAsync = async (db: DocumentClient, id: string, fields: Us
  * @param data User Data
  * @returns User
  */
-const AddOrUpdateUserAsync = async (db: DocumentClient, data: PutItemInputAttributeMap): Promise<User> => {
+const AddOrUpdateUserAsync = async (db: DocumentClient, data: PutItemInputAttributeMap, create = false): Promise<User> => {
 	try {
 		const params: PutItemInput = {
 			TableName: tableName,
 			Item: data,
+		}
+
+		if (create) {
+			params.ConditionExpression = 'attribute_not_exists(id)'
+		} else {
+			params.ConditionExpression = 'attribute_exists(id)'
 		}
 
 		await db

--- a/solution/server/tests/unit/user-data-access.test.ts
+++ b/solution/server/tests/unit/user-data-access.test.ts
@@ -429,6 +429,20 @@ describe('Data access - ListUsersAsync tests', () => {
 		expect(await ListUsersAsync(ddb, listingParams)).toEqual(expected)
 	})
 
+	it('should ListUsersAsync throw when receiving an invalid response from server', async () => {
+		AWSMock.mock('DynamoDB.DocumentClient', 'scan', (_params: ScanInput, callback: (err: AWSError | null, data: ScanOutput) => void) => {
+			callback(null, { Items: undefined })
+		})
+
+		const ddb = new AWS.DynamoDB.DocumentClient()
+
+		try {
+			await ListUsersAsync(ddb, {})
+		} catch (error) {
+			expect(error.message).toMatch('Error on User list')
+		}
+	})
+
 	it('should ListUsersAsync throw when receiving an error from server', async () => {
 		AWSMock.mock('DynamoDB.DocumentClient', 'scan', (_params: ScanInput, callback: (err: AWSError | null, data: ScanOutput) => void) => {
 			callback({ code: '', message: '', name: '', time: new Date() }, {})


### PR DESCRIPTION
Update checks when adding or updating a user: id must not exist when creating and must exist when updating. Added a test case to cover invalid response on ListUsersAsync and improved status code check when fetching data from Mapbox API